### PR TITLE
set the default env prepending ~/.rbenv/shims and ~/.rbenv/bin to $PATH

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -52,5 +52,9 @@ namespace :load do
 
     set :rbenv_ruby_dir, -> { "#{fetch(:rbenv_path)}/versions/#{fetch(:rbenv_ruby)}" }
     set :rbenv_map_bins, %w{rake gem bundle ruby}
+
+    default_env = fetch :default_env, {}
+    default_env[:path] = "#{fetch(:rbenv_path)}/shims:#{fetch(:rbenv_path)}/bin:$PATH"
+    set :default_env, default_env
   end
 end


### PR DESCRIPTION
Please see [stackoverflow this thread](http://stackoverflow.com/questions/19716131/usr-bin-env-ruby-no-such-file-or-directory-using-capistrano-3-capistrano-rben).

Using this plugin without setting the `default_env` was causing `/usr/bin/env ruby : Not such file or directory`. I figured how to solve it (see the solution I found in stackoverflow) and I this change fixes it.

Thank you!
