### PR TITLE
Extract `rbenv_prefix` to config variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   This gives us more flexible integration and command mapping.
   Fixed bug when `cap some_task` didn't invoke rbenv hooks.
 
+* Added ability to setup custom `rbenv_prefix` variable.
+
 # 0.0.1
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ And then execute:
     # config/deploy.rb
     set :rbenv_type, :user # or :system, depends on your rbenv setup
     set :rbenv_ruby, '2.0.0-p247'
+    set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 
 If your rbenv is located in some custom path, you can use `rbenv_custom_path` to set it.
 

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -15,8 +15,7 @@ namespace :rbenv do
   end
 
   task :map_bins do
-    rbenv_prefix = "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
-
+    rbenv_prefix = fetch(:rbenv_prefix, proc { "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec" })
     SSHKit.config.command_map[:rbenv] = "#{fetch(:rbenv_path)}/bin/rbenv"
 
     fetch(:rbenv_map_bins).each do |command|


### PR DESCRIPTION
To not duplicate to use the RBENV variables and provide custom rbenv_prefix, added ability to provide custom rbenv_prefix and now we can setup it from the `deploy.rb`.

``` ruby
set :rbenv_prefix, "RBENV_ROOT=/data/apps/work RBENV_GEMSET=global ..."
```

Also in other part of deploy recipes, we can use this value:

``` ruby
SSHKit.config.command_map.prefix[:custom].unshift(fetch(:rbenv_prefix))
```
