### PR TITLE
Broaden sshkit dependency to >= 1.2.0

### DIFF
--- a/capistrano-rbenv.gemspec
+++ b/capistrano-rbenv.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 3.0'
-  gem.add_dependency 'sshkit', '~> 1.2.0'
+  gem.add_dependency 'sshkit', '~> 1.3'
 
 end


### PR DESCRIPTION
SSHKit 1.3.0 was recently released with a huge speed improvement due by reusing ssh connections.

`capistrano-rbenv` was preventing the upgrade since it was locked to a 1.2.x version of sshkit. I would assume it would be safe to use any 1.x version, so this broadens the requirement a little.

**Update**: I changed it to `>= 1.2.0` instead of `~1.3`
