### PR TITLE
Lets use inline array instead passed array as param

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -1,6 +1,6 @@
 namespace :rbenv do
   task :validate do
-    on roles(fetch(:rbenv_roles)) do
+    on roles(*fetch(:rbenv_roles)) do
       rbenv_ruby = fetch(:rbenv_ruby)
       if rbenv_ruby.nil?
         error "rbenv: rbenv_ruby is not set"


### PR DESCRIPTION
I have already create the same changes for the capistrano/bundler gem.

Example of the problem:

```
set :bundle_roles, %w{web jobs}
```

For the current version it will raise exception on role_filter like:

```
undefined method `to_sym' for ["web", "jobs"]:Array
vendor/bundle/ruby/2.1.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:25:in `each'
```

Example for this change: https://gist.github.com/oivoodoo/8342230
