### PR TITLE
Set environment variables by extending default_env

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -15,7 +15,8 @@ namespace :rbenv do
   end
 
   task :map_bins do
-    rbenv_prefix = fetch(:rbenv_prefix, proc { "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec" })
+    SSHKit.config.default_env.merge!({ rbenv_root: fetch(:rbenv_path), rbenv_version: fetch(:rbenv_ruby) })
+    rbenv_prefix = fetch(:rbenv_prefix, proc { "#{fetch(:rbenv_path)}/bin/rbenv exec" })
     SSHKit.config.command_map[:rbenv] = "#{fetch(:rbenv_path)}/bin/rbenv"
 
     fetch(:rbenv_map_bins).each do |command|


### PR DESCRIPTION
I'm not fully sure if this is a good solution, because now the environment variables are always set, but it keeps non-command parts of the command out of the `command_map`
