### PR TITLE
Added tasks to allow rbenv setup, update and rubies installation.

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -23,10 +23,38 @@ namespace :rbenv do
       SSHKit.config.command_map.prefix[command.to_sym].unshift(rbenv_prefix)
     end
   end
+
+  task :setup do
+    on roles(fetch(:rbenv_roles)) do
+      execute :git, 'clone', fetch(:rbenv_git_url), fetch(:rbenv_path)
+      execute :git, 'clone', fetch(:ruby_build_git_url), fetch(:ruby_build_path)
+    end
+  end
+
+  task :update do
+    on roles(fetch(:rbenv_roles)) do
+      [fetch(:rbenv_path), fetch(:ruby_build_path)].each do |update_path|
+        within update_path do
+          execute :git, 'pull'
+        end
+      end
+    end
+  end
+
+  task :install, [:new_ruby] do |task, args|
+    on roles(fetch(:rbenv_roles)) do
+      execute :rbenv, 'install', args[:new_ruby] || fetch(:rbenv_ruby)
+      execute :rbenv, 'local', args[:new_ruby] || fetch(:rbenv_ruby)
+      execute :rbenv, 'rehash'
+      execute :gem, 'install', 'bundler' unless fetch(:bundle_roles)
+      execute :rbenv, 'rehash'
+    end
+  end
 end
 
 Capistrano::DSL.stages.each do |stage|
-  after stage, 'rbenv:validate'
+  current_tasks = Rake.application.top_level_tasks.join(' ')
+  after stage, 'rbenv:validate' if !current_tasks.match(/rbenv.(setup|install)/)
   after stage, 'rbenv:map_bins'
 end
 
@@ -45,5 +73,9 @@ namespace :load do
 
     set :rbenv_ruby_dir, -> { "#{fetch(:rbenv_path)}/versions/#{fetch(:rbenv_ruby)}" }
     set :rbenv_map_bins, %w{rake gem bundle ruby rails}
+
+    set :ruby_build_path, -> { '%s/plugins/ruby-build' % fetch(:rbenv_path) }
+    set :rbenv_git_url, 'git://github.com/sstephenson/rbenv.git'
+    set :ruby_build_git_url, 'git://github.com/sstephenson/ruby-build.git'
   end
 end


### PR DESCRIPTION
Setting up rbenv is a pretty trivial task so I added a couple of tasks to help manage this.

This might not be the case for everyone, but I thought I should propose first before putting it in a separate gem.

There are 3 new tasks and 3 new config directives:
- `rbenv:setup` - installs rbenv remotely
- `rbenv:update` - updates the rbenv installation
- `rbenv:install[RUBY_VERSION]` - installs a rubie, in case you want to upgrade the ruby version
- `ruby_build_path` - this will use ruby build to manage rubies installation, this option is where it should be installed, defaults to `$RBENV_PATH/plugins/ruby-build`
- `rbenv_git_url` - the git url to use for setup, defaults to @sstephenson/rbenv
- `ruby_build_git_url` - the git url to use for installing ruby-build, defaults to @sstephenson/ruby-build

Thanks.
