### PR TITLE
rbenv.rake: using a simpler File.directory? test

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -7,7 +7,7 @@ namespace :rbenv do
         exit 1
       end
 
-      if test "[ ! -d #{fetch(:rbenv_ruby_dir)} ]"
+      unless File.directory? fetch(:rbenv_ruby_dir)
         error "rbenv: #{rbenv_ruby} is not installed or not found in #{fetch(:rbenv_ruby_dir)}"
         exit 1
       end


### PR DESCRIPTION
This is preferable to forking, and the previous test did not seem to work.

Error seen:

```
DEBUG [a4479203] Running /usr/bin/env [ ! -d /usr/local/rbenv/versions/jruby-1.7.11; ] on vagrant-devtest
DEBUG [a4479203] Command: [ ! -d /usr/local/rbenv/versions/jruby-1.7.11; ]
DEBUG [a4479203]    bash: line 0: [: missing `]'
DEBUG [a4479203]    bash: ]: command not found
```
