### PR TITLE
Make rbenv:validate task give positive output

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -7,7 +7,7 @@ namespace :rbenv do
         exit 1
       end
 
-      if test "[ ! -d #{fetch(:rbenv_ruby_dir)} ]"
+      if not test "[ -d #{fetch(:rbenv_ruby_dir)} ]"
         error "rbenv: #{rbenv_ruby} is not installed or not found in #{fetch(:rbenv_ruby_dir)}"
         exit 1
       end


### PR DESCRIPTION
Fixes #23. Now nobody worries since we don't output 'failed'.

```
DEBUG [c7501a58] Running /usr/bin/env [ -d /opt/rbenv/versions/1.9.3-p484 ] on yourserver.com
DEBUG [c7501a58] Command: [ -d /opt/rbenv/versions/1.9.3-p484 ]
DEBUG [c7501a58] Finished in 0.511 seconds with exit status 0 (successful).
```
