### PR TITLE
Expand home dir for user rbenv_path to support quoted ENV in SSHKit

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         "/usr/local/rbenv"
       else
-        "~/.rbenv"
+        "/home/#{fetch(:deploy_user)}/.rbenv"
       end
     }
 


### PR DESCRIPTION
As a result of https://github.com/capistrano/sshkit/pull/250 for user installs of rbenv result in incorrect ENV in the mapped bins.

So what used to be this:
`$ RBENV_ROOT=~/.rbenv RBENV_VERSION=2.2.2 ~/.rbenv/bin/rbenv exec gem query --quiet --installed --name-matches ^bundler$`

Became this:
`RBENV_ROOT="~/.rbenv" RBENV_VERSION="2.2.2" ~/.rbenv/bin/rbenv exec gem query --quiet --installed --name-matches ^bundler$`

In other words path expansion was no longer occurring due to the quotes added by SSHKit.  This is easy to workaround by overriding the default rbenv_path property, however this PR sets the default to the expanded path so that is no longer necessary.