### PR TITLE
Fix user rbenv installs to use $HOME instead of ~

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         "/usr/local/rbenv"
       else
-        "~/.rbenv"
+        "$HOME/.rbenv"
       end
     }
 


### PR DESCRIPTION
As a result of https://github.com/capistrano/sshkit/pull/250 user installs of rbenv result in incorrect ENV in the mapped bins.  SSHKit now quotes all ENV values, resulting in the rbenv root path to not be expanded, and thus invalid.

So what used to be this:
`RBENV_ROOT=~/.rbenv RBENV_VERSION=2.2.2 ~/.rbenv/bin/rbenv exec gem query --quiet --installed --name-matches ^bundler$`

Became this:
`RBENV_ROOT="~/.rbenv" RBENV_VERSION="2.2.2" ~/.rbenv/bin/rbenv exec gem query --quiet --installed --name-matches ^bundler$`

This is easy to workaround by explicitly setting the `rbenv_path` property, however the default behavior is broken when using the latest SSHKit.

This PR changes the install path to use $HOME instead of ~