### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ And then execute:
     # set :rbenv_ruby, File.read('.ruby-version').strip
 
     set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
-    set :rbenv_map_bins, %w{rake gem bundle ruby rails}
     set :rbenv_roles, :all # default value
 
 If your rbenv is located in some custom path, you can use `rbenv_custom_path` to set it.


### PR DESCRIPTION
This line is misleading. It will override the `rbenv_map_bins`, and will lead to some unexpected issue to others packages.

https://github.com/seuros/capistrano-sidekiq/issues/124
