### PR TITLE
Use $HOME instead of ~ so sshkit 1.8.0 works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+* Change default `rbenv_path` to use `$HOME` instead of `~`. This allows
+  capistrano-rbenv to work with the new quoting behavior of sshkit 1.8.0.
+
 # 2.0.3 (27 Jan 2015)
 
 * rbenv:validate is a 'success' if version exists #36

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         "/usr/local/rbenv"
       else
-        "~/.rbenv"
+        "$HOME/.rbenv"
       end
     }
 


### PR DESCRIPTION
sshkit 1.8.0 introduced quoting of environment variable values. This means that rbenv commands would execute with `RBENV_HOME="~/.rbenv"` (notice the double quotes). The `~` is not expanded by the shell when placed in quotes, so this breaks rbenv.

This commit fixes sshkit 1.8.0 compatibility by using `$HOME` instead of `~`. Dollar-sign variables are still expanded within double quoted strings, so this works: `RBENV_HOME="$HOME/.rbenv"`.

I've tested using one of my own projects with this simple task:

```ruby
task :check_check do
  on roles(:all) do
    execute :ruby, "--version"
  end
end
```

Using sshkit 1.8.0, before this fix:

```
rbenv: version `2.2.3' is not installed (set by RBENV_VERSION environment variable)
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deployer@x.x.x.x: ruby exit status: 1
ruby stdout: Nothing written
ruby stderr: rbenv: version `2.2.3' is not installed (set by RBENV_VERSION environment variable)

SSHKit::Command::Failed: ruby exit status: 1
ruby stdout: Nothing written
ruby stderr: rbenv: version `2.2.3' is not installed (set by RBENV_VERSION environment variable)
```

With this PR applied:

```
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
```

See related bug report here: https://github.com/capistrano/sshkit/issues/303