### PR TITLE
Use $HOME instead of ~ for RBENV_ROOT

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         "/usr/local/rbenv"
       else
-        "~/.rbenv"
+        "$HOME/.rbenv"
       end
     }
 


### PR DESCRIPTION
Using the `~` here causes issues on both Ubuntu and CentOS that I have yet to isolate:

```
$ export RBENV_ROOT="~/.rbenv" RBENV_VERSION=2.1.6; ~/.rbenv/bin/rbenv exec ruby -v
rbenv: version `2.1.6' is not installed (set by RBENV_VERSION environment variable)

$ export RBENV_ROOT="$HOME/.rbenv" RBENV_VERSION=2.1.6; ~/.rbenv/bin/rbenv exec ruby -v
ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-linux]
```