### PR TITLE
add support sshkit >= 1.9.0

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -1,3 +1,5 @@
+include SSHKit::DSL
+
 namespace :rbenv do
   task :validate do
     on release_roles(fetch(:rbenv_roles)) do


### PR DESCRIPTION
Due to sshkit 1.9 requires explicitly include it, rbenv does not work with new versions. 