### PR TITLE
Make rbenv_ruby optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ And then execute:
 
 If your rbenv is located in some custom path, you can use `rbenv_custom_path` to set it.
 
+### Defining the ruby version
+
+To set the Ruby version explicitly, add `:rbenv_ruby` to your Capistrano configuration:
+
+    # config/deploy.rb
+    set :rbenv_ruby, '2.0.0-p247'
+
+Alternatively, allow the remote host's `rbenv` to [determine the appropriate Ruby version](https://github.com/rbenv/rbenv#choosing-the-ruby-version) by omitting `:rbenv_ruby`. This approach is useful if you have a `.ruby-version` file in your project.
+
 ## Contributing
 
 1. Fork it

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -3,12 +3,12 @@ namespace :rbenv do
     on release_roles(fetch(:rbenv_roles)) do
       rbenv_ruby = fetch(:rbenv_ruby)
       if rbenv_ruby.nil?
-        error "rbenv: rbenv_ruby is not set"
-        exit 1
+        warn "rbenv: rbenv_ruby is not set"
       end
 
-      unless test "[ -d #{fetch(:rbenv_ruby_dir)} ]"
-        error "rbenv: #{rbenv_ruby} is not installed or not found in #{fetch(:rbenv_ruby_dir)}"
+      # don't check the rbenv_ruby_dir if :rbenv_ruby is not set (it will always fail)
+      unless rbenv_ruby.nil? || (test "[ -d #{fetch(:rbenv_ruby_dir)} ]")
+        warn "rbenv: #{rbenv_ruby} is not installed or not found in #{fetch(:rbenv_ruby_dir)}"
         exit 1
       end
     end


### PR DESCRIPTION
This PR addresses #61 and resolves the issue where the Ruby version changes between the current and new releases.

By removing the requirement for `:rbenv_ruby`, we can delegate the decision to the remote host's `rbenv`, which will follow [these steps](https://github.com/rbenv/rbenv#choosing-the-ruby-version) to choose a version. This mitigates the above problem by using the 'old' Ruby version to run commands on `current`, and the 'new' Ruby version on the release in progress.
