### PR TITLE
Add hanami to rbenv_map_bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [master][]
 
-* Your contribution here!
+* Add hanami to `rbenv_map_bins`
 
 # [2.1.0][] (4 Dec 2016)
 

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -44,6 +44,6 @@ namespace :load do
     set :rbenv_roles, fetch(:rbenv_roles, :all)
 
     set :rbenv_ruby_dir, -> { "#{fetch(:rbenv_path)}/versions/#{fetch(:rbenv_ruby)}" }
-    set :rbenv_map_bins, %w{rake gem bundle ruby rails}
+    set :rbenv_map_bins, %w{rake gem bundle ruby rails hanami}
   end
 end


### PR DESCRIPTION
This is necessary so that you can run the command `hanami` through method` execute`.

[Hanami](https://github.com/hanami/hanami) is a full-stack Ruby web framework.

Example:
```ruby
namespace :deploy do
  task :hanami_help do
    on roles(:app) do
      within release_path do
        with hanami_env: fetch(:hanami_env) do
          execute :hanami, 'help'
        end
      end
    end
  end
end
```