### PR TITLE
Update validation message if rbenv_ruby is not set

### DIFF
--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -3,7 +3,7 @@ namespace :rbenv do
     on release_roles(fetch(:rbenv_roles)) do
       rbenv_ruby = fetch(:rbenv_ruby)
       if rbenv_ruby.nil?
-        warn "rbenv: rbenv_ruby is not set"
+        info 'rbenv: rbenv_ruby is not set; ruby version will be defined by the remote hosts via rbenv'
       end
 
       # don't check the rbenv_ruby_dir if :rbenv_ruby is not set (it will always fail)
@@ -35,9 +35,9 @@ namespace :load do
     set :rbenv_path, -> {
       rbenv_path = fetch(:rbenv_custom_path)
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
-        "/usr/local/rbenv"
+        '/usr/local/rbenv'
       else
-        "$HOME/.rbenv"
+        '$HOME/.rbenv'
       end
     }
 


### PR DESCRIPTION
Hi,
I use new capistrano/rbenv feature that allows not to define `rbenv_ruby` in config file.
But the warning message wasn't updated and now it seems a little bit confusing to me.

If I intentionally removed `rbenv_ruby` from capistrano config "rbenv: rbenv_ruby is not set" looks like I still do something wrong.

It is already said in README
> Alternatively, allow the remote host's rbenv to determine the appropriate Ruby version by omitting :rbenv_ruby. This approach is useful if you have a .ruby-version file in your project.

So I think it would be better to add this notice directly to the message.

P. S.
I am not sure about words in the message. Is `remote hosts` better than `deployed hosts`?