### PR TITLE
Ensure that all rbenv_map_bins entries are unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [master][]
 
 * Your contribution here!
-* Enforce uniqueness of rbenv_map_bins.
+* [#75](https://github.com/capistrano/rbenv/pull/75): Enforce uniqueness of rbenv_map_bins.
 
 # [2.1.2][] (29 Sep 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* Enforce uniqueness of rbenv_map_bins.
 
 # [2.1.2][] (29 Sep 2017)
 

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -19,7 +19,7 @@ namespace :rbenv do
     rbenv_prefix = fetch(:rbenv_prefix, proc { "#{fetch(:rbenv_path)}/bin/rbenv exec" })
     SSHKit.config.command_map[:rbenv] = "#{fetch(:rbenv_path)}/bin/rbenv"
 
-    fetch(:rbenv_map_bins).each do |command|
+    fetch(:rbenv_map_bins).uniq.each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(rbenv_prefix)
     end
   end


### PR DESCRIPTION
Make life easier in situations like this: https://github.com/capistrano/capistrano/pull/1936

It makes no sense to have duplicate `rbenv_map_bins` entries, so `#uniq` them before usage.