### PR TITLE
Fix issue with sshkit escaping `$HOME`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Your contribution here!
 
+# [2.1.5][] (12 Jan 2019)
+
+* [#88](https://github.com/capistrano/rbenv/pull/88): Fix issue with sshkit escaping `$HOME`
+
 # [2.1.4][] (8 Sep 2018)
 
 * [#82](https://github.com/capistrano/rbenv/pull/82): Specify MIT license in gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # [master][]
 
 * Your contribution here!
-
-# [2.1.5][] (12 Jan 2019)
-
 * [#88](https://github.com/capistrano/rbenv/pull/88): Fix issue with sshkit escaping `$HOME`
 
 # [2.1.4][] (8 Sep 2018)

--- a/capistrano-rbenv.gemspec
+++ b/capistrano-rbenv.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "capistrano-rbenv"
-  gem.version       = '2.1.5'
+  gem.version       = '2.1.4'
   gem.authors       = ["Kir Shatrov", "Yamashita Yuu"]
   gem.email         = ["shatrov@me.com", "yamashita@geishatokyo.com"]
   gem.description   = %q{rbenv integration for Capistrano}

--- a/capistrano-rbenv.gemspec
+++ b/capistrano-rbenv.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "capistrano-rbenv"
-  gem.version       = '2.1.4'
+  gem.version       = '2.1.5'
   gem.authors       = ["Kir Shatrov", "Yamashita Yuu"]
   gem.email         = ["shatrov@me.com", "yamashita@geishatokyo.com"]
   gem.description   = %q{rbenv integration for Capistrano}

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         '/usr/local/rbenv'
       else
-        '$HOME/.rbenv'
+        '~/.rbenv'
       end
     }
 


### PR DESCRIPTION
It appears that in `sshkit` everything is being escaped except for the "~" sign here: https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/abstract.rb#L85

So on the code I have changed it runs this check:

```
if test ! -d \$HOME/.rbenv/plugins/ruby-build; then echo "Directory does not exist '\$HOME/.rbenv/plugins/ruby-build'" 1>&2; false; fi
```

instead of this check:

```
if test ! -d $HOME/.rbenv/plugins/ruby-build; then echo "Directory does not exist '\$HOME/.rbenv/plugins/ruby-build'" 1>&2; false; fi
```

Note the missing `\` before `$HOME`.

I believe this is intended functionality on `sshkit`, so I'm not creating a PR over there. However that causes an issue here, where it will never return correctly there, even if the directory `$HOME/.rbenv` exists.

To fix the issue, I replaced `$HOME` with `~` which when deploying with my version of the gem, everything then works correctly.