### PR TITLE
Revert "Fix issue with sshkit escaping `$HOME` (#88)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* Revert [#88](https://github.com/capistrano/rbenv/pull/88): Fix issue with sshkit escaping `$HOME`
 
 # [2.1.5][] (14 Jan 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [master][]
 
 * Your contribution here!
-* Revert [#88](https://github.com/capistrano/rbenv/pull/88): Fix issue with sshkit escaping `$HOME`
+* [#89](https://github.com/capistrano/rbenv/pull/89): Revert [#88](https://github.com/capistrano/rbenv/pull/88) Fix issue with sshkit escaping `$HOME`
 
 # [2.1.5][] (14 Jan 2020)
 

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       rbenv_path ||= if fetch(:rbenv_type, :user) == :system
         '/usr/local/rbenv'
       else
-        '~/.rbenv'
+        '$HOME/.rbenv'
       end
     }
 


### PR DESCRIPTION
This reverts commit fea2cf74252bb0831d1dfc95243ff29a64a72e3e.

Fixes the following error introduced by #88:

```
 DEBUG [89e42fce] Command: cd /var/www/oauth2id/releases/20200115021955 && ( export RBENV_ROOT="~/.rbenv" RBENV_VERSION="2.6.5" ; ~/.rbenv/bin/rbenv exec bundle install --path /var/www/oauth2id/shared/bundle --jobs 4 --without development test --deployment --quiet )

 DEBUG [89e42fce] 	rbenv: version `2.6.5' is not installed (set by RBENV_VERSION environment variable)
```