### PR TITLE
Document `rbenv_ruby_dir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ And then execute:
 
     # in case you want to set ruby version from the file:
     # set :rbenv_ruby, File.read('.ruby-version').strip
+    
+    # in case you use fullstaq-ruby or have a different path for your ruby versions
+    # set :rbenv_ruby_dir, '/usr/lib/fullstaq-ruby/versions' 
 
     set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
     set :rbenv_map_bins, %w{rake gem bundle ruby rails}


### PR DESCRIPTION
Hi, I'm using fullstaqruby on a new server (https://github.com/fullstaq-labs/fullstaq-ruby-server-edition), it's an optimized ruby distribution that integrates nicely with rbenv.

The only problem I found was when capistrano-rbenv tried to check the versions folder. Checking the code I found that it was possible to change the value of rbenv_ruby_dir and worked great.

I've also had to modify the path to the rbenv bin file, but that's more or less documented (modifying the :rbenv_prefix setting), that can probably be documented on the fullstaqruby github readme.

If you are ok I think it would be good to document the option, in case someone else find itself in the same position :)