### PR TITLE
Explicit support for Fullstaq Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* [#92](https://github.com/capistrano/rbenv/pull/92): Explicit support for Fullstaq Ruby - [@FooBarWidget](https://github.com/FooBarWidget)
 
 # [2.1.6][] (14 Jan 2020)
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,11 @@ And then execute:
 
 
     # config/deploy.rb
-    set :rbenv_type, :user # or :system, depends on your rbenv setup
+    set :rbenv_type, :user # or :system, or :fullstaq (for Fullstaq Ruby), depends on your rbenv setup
     set :rbenv_ruby, '2.4.2'
 
     # in case you want to set ruby version from the file:
     # set :rbenv_ruby, File.read('.ruby-version').strip
-    
-    # in case you use fullstaq-ruby or have a different path for your ruby versions
-    # set :rbenv_ruby_dir, '/usr/lib/fullstaq-ruby/versions' 
 
     set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
     set :rbenv_map_bins, %w{rake gem bundle ruby rails}

--- a/lib/capistrano/tasks/rbenv.rake
+++ b/lib/capistrano/tasks/rbenv.rake
@@ -34,8 +34,11 @@ namespace :load do
   task :defaults do
     set :rbenv_path, -> {
       rbenv_path = fetch(:rbenv_custom_path)
-      rbenv_path ||= if fetch(:rbenv_type, :user) == :system
+      rbenv_path ||= case fetch(:rbenv_type, :user)
+      when :system
         '/usr/local/rbenv'
+      when :fullstaq
+        '/usr/lib/rbenv'
       else
         '$HOME/.rbenv'
       end


### PR DESCRIPTION
Fullstaq Ruby installs Ruby to /usr/lib/fullstaq-ruby/versions (of which /usr/lib/rbenv/versions is a symlink to). The currently documented way to support this is via setting `rbenv_ruby` to /usr/lib/fullstaq-ruby/versions, as implemented in pull request #91. However, the drawback of this approach is that SSHKit command mappings don't work. When one calls...

    execute(:ruby, '-v')

...capistrano-rbenv ends up executing $HOME/.rbenv/bin/rbenv. But Rbenv is not installed there, but in /usr/lib/rbenv/bin/rbenv.

This change adds full support for Fullstaq Ruby, in a way that makes SSHKit command mappings work.

Requires Fullstaq Ruby epic 3.3. See also:
https://github.com/fullstaq-labs/fullstaq-ruby-server-edition/pull/47#issuecomment-634063302